### PR TITLE
fixed flaky test (  order dependency from test

### DIFF
--- a/tests/test_command_context.py
+++ b/tests/test_command_context.py
@@ -24,9 +24,7 @@ def test_manual_context_noccr():
         {"spaghetti": DoNothing()},
         ccr=False
     )
-    # Loaded rule should be referencing the original
-    # "test" context loaded above, which should already be
-    # active
+    engine.mimic(["enable", "test"])
     engine.mimic(["spaghetti"])
     engine.mimic(["disable", "test"])
     with pytest.raises(MimicFailure):


### PR DESCRIPTION
Tests should be able to be ran independently. My proposed change removes the order dependency in the execution of `test_manual_context_noccr` test. Thus, this test would no longer fail because of an independent (isolated) run or a run in a different execution order.