### PR TITLE
Potential Flaky Test fix.

### DIFF
--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -8,7 +8,9 @@ engine = get_engine("text")
 script_dir = os.path.dirname(__file__)
 file_path = os.path.join(script_dir, "my_grammar/fruit.py")
 
+
 def test_loading_failure():
+    test_clear()
     with open(file_path, "w") as f:
         f.write("""
 from breathe import Breathe


### PR DESCRIPTION
The result is genearted by: pytest flakefinder: https://github.com/dropbox/pytest-flakefinder
The fix is aiming at test_loading.py, several flaky tests detected due to Breathe module pollution. (Order dependent)
My fix: calling test_clear() in loading_failure to prevent pollution.
Original report:(partial)
```
>       assert len(Breathe.modules) == 1
E       AssertionError: assert 50 == 1
E        +  where 50 = len(['tests.my_grammar.fruit', 'tests.my_grammar.fruit', 'tests.my_grammar.fruit', 'tests.my_grammar.fruit', 'tests.my_grammar.fruit', 'tests.my_grammar.fruit', ...])
E        +    where ['tests.my_grammar.fruit', 'tests.my_grammar.fruit', 'tests.my_grammar.fruit', 'tests.my_grammar.fruit', 'tests.my_grammar.fruit', 'tests.my_grammar.fruit', ...] = Master(Merger).modules

test_loading.py:72: AssertionError
```
After fixing:
passed normal pytest runs, 200 runs of flake-finder by default and 4000 runs of flake-finder