### PR TITLE
flaky test fix

### DIFF
--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -16,6 +16,7 @@ engine = get_engine("text")
 
 
 def test_global_extras():
+    test_clear()
     Breathe.add_global_extras(Dictation("text"))
     assert len(Breathe.global_extras) == 1
     assert "text" in Breathe.global_extras
@@ -64,6 +65,11 @@ def test_noccr_commands():
 
 
 def test_grammar_numbers():
+    test_clear()
+    test_global_extras()
+    test_core_commands()
+    test_context_commands()
+    test_noccr_commands()
     engine.mimic(["test", "three"])
     # Ensure that we are not adding more grammars than necessary
     assert len(engine.grammars) == 4

--- a/tests/test_top_level.py
+++ b/tests/test_top_level.py
@@ -53,6 +53,10 @@ def test_global_top_level():
     )
 
 def test_recognition():
+    test_clear()
+    test_top_level_command()
+    test_top_level_command2()
+    test_global_top_level()
     engine.mimic("lemon", executable="notepad")
     engine.mimic("fruit from lemon banana orange and five", executable="notepad")
 
@@ -71,6 +75,10 @@ def test_recognition():
     assert len(Breathe.top_level_commands) == 2
 
 def test_top_level_command_failure():
+    test_clear()
+    test_top_level_command()
+    test_top_level_command2()
+    test_global_top_level()
     Breathe.add_commands(
         AppContext("china"),
         {


### PR DESCRIPTION
Order dependent flaky test fix.
Fixing is putting all preset functions before assertion and clear every time to prevent polluting Breathe object 
Run commands:
```
pytest --flake-finder tests/test_top_level.py
```
to see the report.
Pytest flakefinder:
https://github.com/dropbox/pytest-flakefinder
Originally 100 tests failed in total 300 tests run.
Fixed code passed 1200 tests run